### PR TITLE
Feature/221259 rebranding changes

### DIFF
--- a/feature-communicate-list.md
+++ b/feature-communicate-list.md
@@ -310,11 +310,11 @@ This option won't show up in single sign on by default from matrix implementatio
 Review your session prompt
 This prompt appears when user is already authenticated. ShowSecurityKeyBackupPrompt has been used to hide this prompt.
 Remove the I trust server prompt screen
-Its been implemented through homeserver.yaml config value.
+Its been implemented through `homeserver.yaml` config value.
 Hide liberate your communication text
-Its been hidden with custom config value ShowLiberateYourCommunicationText in our config.
+Its been hidden with custom config value `ShowLiberateYourCommunicationText` in our config.
 ACT government logo
-A secondary image has been used and read from config value logo_secondary.imgUrl. This uses standard ACT Govt Logo which is horizontal.
+A secondary image has been used and read from config value `logo.logo_secondary.imgUrl`. This uses standard ACT Govt Logo which is horizontal.
 ACT government logo on pre login screen
 Vertical ACT government logo has been used for this purpose. A config value cant be used for this as app-web is not query that setting in front end. Only on react sdk you can use config to retrieve that value. This one uses ACT gov logo that ends with _vertical keyword.
 
@@ -330,3 +330,13 @@ Web: Sign In Screen Lingo Re-Branding and Update
  which is configurable flag to control image description and we can change this description on config file as we want and this description would aid `WCAG` compliance on image description. This config centralizes all secondary logo  values such as `margin`, `height`, `logo url`, `logo description` etc. which are easily configurable and can be done through config changes in future.
  - Footer for unauthenticated content from matrix default has been turned off by using `showMatrixDefaultFooterLinks` flag which is also used for replacing copyright content of matrix with customized ones from clients.
  - Unauthenticated footer content is going to use customized communicate logo and text label which is private information so instead of hardcoding it , it has been configured from `footer` config value so now WCAG accessibility text for image and footer description won't be part of component even though image is referenced there. There is chance to configure all styles for footer logo, and text labels. Mostly idea of configuring style for anything in UI has been to minimize code changes and be able to change height of image used promptly.
+ These other flags control login screen and home screen display
+to manage logos properly `logo` config value has been added in config which controls values and boolean fields containing logo logic as well as values for styling in general for logo such as `height`.
+ - `showPrimaryLogoOnLoginScreen` controls whether or not to show primary logo on logon screen window.
+ - `showPrimaryLogoInAuthenticatedScreen` controls whether or not to show secondary logo on authenticated screen.
+ - `showSecondaryLogoOnLoginScreen` controls whether or not to show secondary logo on logon screen window which has forms.
+ - `showSecondaryLogoOnAuthenticatedSreen` controls whether or not to show secondary logo when user is authenticated. This logic could be used wherever secondaryLogo is used in authenticated page when i.e. top left, footer, in middle or whatnot.
+ - `showWelcomeToElementText` controls whether or not to show "welcome to element" message when user is logged in.
+ - `showLoginScreenBackgroundImage` controls whether or not to show lake image or any other background images on login screen.
+ - `backgroundColor` is used by view to render colored background which turns into a bogus url instead of real url.
+ - `secondaryLogo` is used by view to render a secondary image which is shown on Login screen or next to primary screen after user is logged in where there is a scenario to use two images.

--- a/res/css/structures/_HomePage.scss
+++ b/res/css/structures/_HomePage.scss
@@ -33,7 +33,7 @@ limitations under the License.
     }
 
     img {
-        height: 48px;
+        height: 120px;
     }
 
     h1 {

--- a/res/css/structures/_TabbedView.scss
+++ b/res/css/structures/_TabbedView.scss
@@ -27,7 +27,9 @@ limitations under the License.
     right: 0;
     margin-top: 8px;
 }
-
+.mx_AuthFooter_Image_Tabbed{
+height: 120px!important;
+}
 .mx_TabbedView_tabLabels {
     width: 170px;
     max-width: 170px;

--- a/res/css/views/auth/_AuthFooter.scss
+++ b/res/css/views/auth/_AuthFooter.scss
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 .mx_AuthFooter {
-    text-align: center;
+    text-align: right;
     width: 100%;
     font-size: $font-14px;
     opacity: 0.72;

--- a/res/css/views/auth/_AuthHeader.scss
+++ b/res/css/views/auth/_AuthHeader.scss
@@ -20,6 +20,7 @@ limitations under the License.
     width: 206px;
     padding: 25px 25px;
     box-sizing: border-box;
+    background-color: white!important;
 }
 
 @media only screen and (max-width: 480px) {

--- a/res/css/views/auth/_AuthHeaderLogo.scss
+++ b/res/css/views/auth/_AuthHeaderLogo.scss
@@ -21,11 +21,30 @@ limitations under the License.
 }
 
 .mx_AuthHeaderLogo img {
-    width: 100%;
+    //width: 100%;
+    width: 150px;
+    height: 100px;
 }
 
 @media only screen and (max-width: 480px) {
     .mx_AuthHeaderLogo {
+        display: none;
+    }
+}
+
+.mx_AuthHeaderLogo_Act{
+    margin-top: 15px;
+    flex: 1;
+    padding: 0 25px;
+    height:100px;
+    width: 100px;
+}
+.mx_AuthHeaderLogo_Act img {
+    height:100px;
+    width: 100px;
+}
+@media only screen and (max-width: 480px) {
+    .mx_AuthHeaderLogo_Act {
         display: none;
     }
 }

--- a/res/css/views/auth/_AuthPage.scss
+++ b/res/css/views/auth/_AuthPage.scss
@@ -19,7 +19,7 @@ limitations under the License.
     min-height: 100%;
     display: flex;
     flex-direction: column;
-    background-color: $authpage-bg-color;
+    background-color: #002677;
 }
 
 .mx_AuthPage_modal {

--- a/res/css/views/auth/_AuthPage.scss
+++ b/res/css/views/auth/_AuthPage.scss
@@ -19,7 +19,7 @@ limitations under the License.
     min-height: 100%;
     display: flex;
     flex-direction: column;
-    background-color: #002677;
+    background-color: #002677!important;
 }
 
 .mx_AuthPage_modal {

--- a/res/themes/light/css/_light.scss
+++ b/res/themes/light/css/_light.scss
@@ -14,7 +14,7 @@ $monospace-font-family: Inconsolata, Twemoji, 'Apple Color Emoji', 'Segoe UI Emo
 
 // unified palette
 // try to use these colors when possible
-$accent-color: #0DBD8B;
+$accent-color:  #002677;
 $accent-bg-color: rgba(3, 179, 129, 0.16);
 $notice-primary-color: #ff4b55;
 $notice-primary-bg-color: rgba(255, 75, 85, 0.16);

--- a/src/components/structures/HomePage.tsx
+++ b/src/components/structures/HomePage.tsx
@@ -33,8 +33,7 @@ import MatrixClientContext from "../../contexts/MatrixClientContext";
 import MiniAvatarUploader, {AVATAR_SIZE} from "../views/elements/MiniAvatarUploader";
 import Analytics from "../../Analytics";
 import CountlyAnalytics from "../../CountlyAnalytics";
-import SettingsStore from "../../settings/SettingsStore";
-import { UIFeature } from "../../settings/UIFeature";
+import * as customConfig from "../../config";
 
 const onClickSendDm = () => {
     Analytics.trackEvent('home_page', 'button', 'dm');
@@ -96,7 +95,8 @@ const UserWelcomeTop = () => {
 const HomePage: React.FC<IProps> = ({ justRegistered = false }) => {
     const config = SdkConfig.get();
     const pageUrl = getHomePageUrl(config);
-    const showLiberateYourCommunicationText = SettingsStore.getValue(UIFeature.ShowLiberateYourCommunicationText);
+    const showWelcomeToElementText = customConfig.showWelcomeToElementText;
+    const showLiberateYourCommunicationText = customConfig.showLiberateYourCommunicationText;
     if (pageUrl) {
         const EmbeddedPage = sdk.getComponent('structures.EmbeddedPage');
         return <EmbeddedPage className="mx_HomePage" url={pageUrl} scrollbar={true} />;
@@ -108,22 +108,25 @@ const HomePage: React.FC<IProps> = ({ justRegistered = false }) => {
     } else {
         const brandingConfig = config.branding;
         let logoUrl = "themes/element/img/logos/element-logo.svg";
-        const logoSecondaryConfig = config['logo_secondary'];
-        const logoUrlSecondary = logoSecondaryConfig?.imgUrl || null;
-        const logoSecondaryDescription = logoSecondaryConfig?.description || config.brand;
-
+        const logoSecondaryDescription = customConfig?.logoSecondary?.description || config.brand;
+        const logoUrlSecondary = config.logo.logo_secondary.imgUrl;
         if (brandingConfig && brandingConfig.authHeaderLogoUrl) {
             logoUrl = brandingConfig.authHeaderLogoUrl;
         }
         const logoSecondaryStyle = {
-           margin: logoSecondaryConfig?.margin || '0 10px',
-           height: logoSecondaryConfig?.height || '55px'
+           margin: customConfig?.logoSecondary?.margin || '0 10px',
+           height: customConfig?.logoSecondary?.height || '55px'
        }
 
         introSection = <React.Fragment>
-            {logoUrlSecondary && <img src={logoUrlSecondary} style={logoSecondaryStyle} alt={logoSecondaryDescription} />}
-            <img src={logoUrl} alt={config.brand} />
+            {customConfig.showSecondaryLogoInAuthenticatedScreen && <img src={logoUrlSecondary} style={logoSecondaryStyle} alt={logoSecondaryDescription} />}
+            {customConfig.showPrimaryLogoInAuthenticatedScreen &&
+            <img src={logoUrl} alt={config.brand}/>
+            }
+            {showWelcomeToElementText ?
             <h1>{ _t("Welcome to %(appName)s", { appName: config.brand }) }</h1>
+            :<h1>{<img src={logoUrl} alt={config.brand}/>}</h1>
+            }
             {showLiberateYourCommunicationText &&
             <h4>{ _t("Liberate your communication") }</h4>
             }

--- a/src/components/structures/HomePage.tsx
+++ b/src/components/structures/HomePage.tsx
@@ -109,7 +109,7 @@ const HomePage: React.FC<IProps> = ({ justRegistered = false }) => {
         const brandingConfig = config.branding;
         let logoUrl = "themes/element/img/logos/element-logo.svg";
         const logoSecondaryDescription = customConfig?.logoSecondary?.description || config.brand;
-        const logoUrlSecondary = config.logo.logo_secondary.imgUrl;
+        const logoUrlSecondary = config.logo?.logo_secondary?.imgUrl;
         if (brandingConfig && brandingConfig.authHeaderLogoUrl) {
             logoUrl = brandingConfig.authHeaderLogoUrl;
         }
@@ -119,10 +119,7 @@ const HomePage: React.FC<IProps> = ({ justRegistered = false }) => {
        }
 
         introSection = <React.Fragment>
-            <img src={logoUrl} alt={config.brand} />
-            {showLiberateYourCommunicationText &&
-            <h4>{ _t("Liberate your communication") }</h4>
-            }
+            <img src={logoUrl} alt={config.brand} />           
         </React.Fragment>;
     }
 

--- a/src/components/structures/HomePage.tsx
+++ b/src/components/structures/HomePage.tsx
@@ -121,9 +121,8 @@ const HomePage: React.FC<IProps> = ({ justRegistered = false }) => {
        }
 
         introSection = <React.Fragment>
-            {logoUrlSecondary && <img src={logoUrlSecondary} style={logoSecondaryStyle} alt={logoSecondaryDescription} />}
             <img src={logoUrl} alt={config.brand} />
-            <h1>{ _t("Welcome to %(appName)s", { appName: config.brand }) }</h1>
+
             {showLiberateYourCommunicationText &&
             <h4>{ _t("Liberate your communication") }</h4>
             }

--- a/src/components/structures/TabbedView.tsx
+++ b/src/components/structures/TabbedView.tsx
@@ -125,6 +125,14 @@ export default class TabbedView extends React.Component<IProps, IState> {
                     {labels}
                 </div>
                 {panel}
+                <div className="mx_AuthFooter_TabbedView">
+                    <a href="" target="_blank" rel="noreferrer noopener">                        
+                    </a>
+                    <span className="mx_AuthFooter_brand_TabbedView">
+                        <img className="mx_AuthFooter_Image_Tabbed" src="themes/element/img/logos/ACTGov_inline_rev_black.png" alt="ACT Govt Logo"/>
+                    </span>
+                </div>
+
             </div>
         );
     }

--- a/src/components/views/auth/AuthHeader.js
+++ b/src/components/views/auth/AuthHeader.js
@@ -29,7 +29,12 @@ export default class AuthHeader extends React.Component {
         const LanguageSelector = sdk.getComponent('views.auth.LanguageSelector');
 
         return (
-            <div className="mx_AuthHeader">
+            <div className="mx_AuthHeader"> 
+                <br/>  
+                <br/> 
+                <div>
+                <img className="mx_AuthHeaderLogo_Act" src="themes/element/img/logos/ACT-Government-inline-back-trans.jpg" alt="ACT Govt Logo"  />                
+                </div>
                 <AuthHeaderLogo />
                 <LanguageSelector disabled={this.props.disableLanguageSelector} />
             </div>

--- a/src/components/views/auth/AuthHeader.js
+++ b/src/components/views/auth/AuthHeader.js
@@ -30,8 +30,7 @@ export default class AuthHeader extends React.Component {
 
         return (
             <div className="mx_AuthHeader"> 
-                <br/>  
-                <br/> 
+                <br/>              
                 <div>
                 <img className="mx_AuthHeaderLogo_Act" src="themes/element/img/logos/ACT-Government-inline-back-trans.jpg" alt="ACT Govt Logo"  />                
                 </div>

--- a/src/components/views/auth/PasswordLogin.tsx
+++ b/src/components/views/auth/PasswordLogin.tsx
@@ -484,7 +484,7 @@ export default class PasswordLogin extends React.PureComponent<IProps, IState> {
                     {forgotPasswordJsx}
                     { !this.props.busy && <input className="mx_Login_submit"
                         type="submit"
-                        value={_t('Sign in')}
+                        value={('Log in')}
                         disabled={this.props.disableSubmit}
                     /> }
                 </form>

--- a/src/components/views/elements/SSOButtons.tsx
+++ b/src/components/views/elements/SSOButtons.tsx
@@ -58,7 +58,7 @@ const SSOButton: React.FC<ISSOButtonProps> = ({
     mini,
     ...props
 }) => {
-    const label = idp ? _t("Continue with %(provider)s", { provider: idp.name }) : _t("Sign in with single sign-on");
+    const label = idp ? _t("Continue with %(provider)s", { provider: idp.name }) : ("Log in with single sign-on");
 
     const onClick = () => {
         PlatformPeg.get().startSingleSignOn(matrixClient, loginType, fragmentAfterLogin, idp?.id);

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,10 @@ const config = SdkConfig.get();
 
 const loginScreen = config['loginScreen'];
 
+const authenticatedHomeScreen = config['authenticatedHomeScreen'];
+
+const logoConfig = config['logo'];
+
 // As the config values are booleans, we use the
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator (??)
 // to safely provide a default boolean value to optional config values that provide boolean values.
@@ -20,7 +24,7 @@ export const signInTextNeedsToBeReplaced = loginScreen?.changeSigninToLoginTextL
 
 // background color on login screen
 // used by app-web to load a colored background instead of lake image
-export const loginScreenBackgroundColor = loginScreen?.backgroundColor ?? null;
+export const showLoginScreenBackgroundImage = loginScreen?.showLoginScreenBackgroundImage ?? null;
 
 // Sign in text - change to login
 export const changeSigninWithLoginTextLabel = () => {
@@ -43,3 +47,29 @@ export const showHomeServerDetail = loginScreen?.showHomeServerInfo ?? true;
 
 // Default footer links
 export const showDefaultFooterLinks = loginScreen?.showMatrixDefaultFooterLinks ?? true;
+
+// show/hide liberate your communication text
+export const showLiberateYourCommunicationText = authenticatedHomeScreen?.showLiberateYourCommunicationText ?? true;
+
+//show/hide welcome to {brand} text
+export const showWelcomeToElementText = authenticatedHomeScreen?.showWelcomeToElementText ?? true;
+
+// show primary logo on logged in screen
+// Due to positioning and etc this switch would make it easy to have that logo configured.
+// it is to control logo that element provides
+export const showPrimaryLogoOnLoginScreen = logoConfig?.showPrimaryLogoOnLoginScreen ?? true;
+
+//show secondary logo after login screen
+//it is to control your own secondary logo that you provide inside logged in screen
+//it can also control footer logo as well if one has been used or needs to be used.
+export const showPrimaryLogoInAuthenticatedScreen = logoConfig?.showPrimaryLogoInAuthenticatedScreen ?? true;
+
+//show secondary logo
+export const showSecondaryLogoOnLogOnScreen = logoConfig?.showSecondaryLogoInLoginScreen ?? false; // default should be false
+
+//show primary logo on login screen
+// Used by loggedin view
+export const showSecondaryLogoInAuthenticatedScreen = logoConfig?.showSecondaryLogoInAuthenticatedScreen ?? false; // default should be false
+
+//find logo secondary
+export const logoSecondary = logoConfig['logo_secondary'] || null;

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -848,10 +848,6 @@ export const SETTINGS: {[setting: string]: ISetting} = {
         supportedLevels: LEVELS_UI_FEATURE,
         default: true
     },
-    [UIFeature.ShowLiberateYourCommunicationText]: {
-        supportedLevels: LEVELS_UI_FEATURE,
-        default: true
-    },
     [UIFeature.ShowSecurityKeyBackupPrompt]: {
         supportedLevels: LEVELS_UI_FEATURE,
         default: true


### PR DESCRIPTION
This pull request brings following changes:

**Feel free to tweak variable names as well if need to but feature doco's variable names needs to be updated if done so**

1)  Vertical logo as secondary log has been replaced in reference as requirement has changed to use regular image
2) Instead of aligning images side by side now they are aligned vertically and branding logo has been made bigger.
3) On log in screen background color has been changed to blue which was not rendered properly previously
4) Welcome To text has been made configurable so if we need to show that additional text then we could do so as well.
5)  Primary and Secondary image on authenticated and unauthenticated page have been added and used to control images placements. 
6) Gap has been aligned but style is pushed to aether-host-file in light.scsss