### PR TITLE
fix bug (view detail not rendering due to description being used as displayName)

### DIFF
--- a/src/components/views/dialogs/InviteDialog.tsx
+++ b/src/components/views/dialogs/InviteDialog.tsx
@@ -375,7 +375,7 @@ class DMRoomTile extends React.PureComponent<IDMRoomTileProps> {
             </AccessibleButton>
 
         const viewMemberDetail = <div id="mx_table_role_detail" style={{ display: 'none' }}>
-            <DirectoryDetailView queryId={this.props.member.name}/>
+            <DirectoryDetailView queryId={this.props.member.userId}/>
         </div>
 
         if (this.props.error) {
@@ -933,7 +933,7 @@ export default class InviteDialog extends React.PureComponent<IInviteDialogProps
 
 				// update favorite roles
 				this._updateFavoritesForCurrentUser();
-				
+
 				// update server result mixin(search result) in state
 				if (response.results.length > 0) {
 					// Don't add search results, for entries for user_id that are already shown


### PR DESCRIPTION
This pull request is quick fix to render view detail as it did not work in test environment at the moment because description field has been used as displayName. 

Service and People directory will align this value properly so that simplifiedId is used for rendering detail all the time and long name and short names are used appropriately.