### PR TITLE
Feature/192347 disable msg removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ already. This project has not yet been migrated to Yarn 2, so please ensure
 `yarn --version` shows a version from the 1.x series.
 
 `matrix-react-sdk` depends on `matrix-js-sdk`. To make use of changes in the
-latter and to ensure tests run against the develop branch of `matrix-js-sdk`,
+later and to ensure tests run against the develop branch of `matrix-js-sdk`,
 you should set up `matrix-js-sdk`:
 
 ```bash

--- a/src/components/views/context_menus/MessageContextMenu.js
+++ b/src/components/views/context_menus/MessageContextMenu.js
@@ -351,7 +351,7 @@ export default class MessageContextMenu extends React.Component {
             );
         }
 
-        if (isSent && this.state.canRedact) {
+        if (isSent && this.state.canRedact && mxEvent.getType() === 'm.room.message') {
             redactButton = (
                 <MenuItem className="mx_MessageContextMenu_field" onClick={this.onRedactClick}>
                     { _t('Remove') }

--- a/src/components/views/context_menus/MessageContextMenu.js
+++ b/src/components/views/context_menus/MessageContextMenu.js
@@ -341,7 +341,7 @@ export default class MessageContextMenu extends React.Component {
             );
         }
 
-        if (isSent && this.state.canRedact) {
+        if (isSent && this.state.canRedact && mxEvent.getType() === 'm.room.message') {
             redactButton = (
                 <MenuItem className="mx_MessageContextMenu_field" onClick={this.onRedactClick}>
                     { _t('Remove') }


### PR DESCRIPTION
**192347 - Administrator or Moderator of chatroom should not be able to see remove option and remove system generated messages that is available on panel.**

This can be tested by hovering on system messages in chat room such as "person x has joined the room...", right click, and remove option wont be available for moderator and admin just for system messages.

Admin and moderator will still have ability to delete chat messages which is default behavior and is required for other parent user story linked in this user story.